### PR TITLE
use express router pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "MIT",
   "main": "source/index.js",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "name": "healthcheck-fastit",
   "scripts": {
     "test": "istanbul cover _mocha -- 'test/*.js'",

--- a/source/index.js
+++ b/source/index.js
@@ -114,7 +114,7 @@ var checkElasticsearch = function(client) {
 
 module.exports = exports = function(params) {
   var urn = params && params.urn ? params.urn : '/api/health-check';
-  var app = express();
+  var app = express.Router();
   app.get(urn, function(req, res) {
     check(params)
       .then(function(result) {


### PR DESCRIPTION
router pattern is better than the sub-app pattern since it avoid server configuration conflict like `app..set('x-powered-by', false);`